### PR TITLE
fix: dynamically configure transport security to prevent 421 errors on VPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /app
 
 # Install dependencies first (cached layer)
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --frozen --no-dev --no-editable
 
 # Copy source code

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Minecraft Wiki MCP
 
-[![smithery badge](https://smithery.ai/badge/@L3-N0X/Minecraft-Wiki-MCP)](https://smithery.ai/server/@L3-N0X/Minecraft-Wiki-MCP)
-
 An MCP Server for browsing the official Minecraft Wiki!
 
 > [!WARNING]
@@ -109,13 +107,16 @@ Then connect clients to `http://127.0.0.1:8000/mcp`. For example, in Claude Code
 claude mcp add --transport http minecraft-wiki http://localhost:8000/mcp
 ```
 
-Configure host and port via environment variables:
+Configure host, port, and security via environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MINECRAFT_WIKI_HOST` | `127.0.0.1` | Host to bind the HTTP server to |
 | `MINECRAFT_WIKI_PORT` | `8000` | Port for the HTTP server |
 | `MINECRAFT_WIKI_API_URL` | `https://minecraft.wiki/api.php` | MediaWiki API endpoint |
+| `MINECRAFT_WIKI_ENABLE_SECURITY` | *Auto* | Enforce DNS rebinding protection (Host/Origin header check). Defaults to `true` if hosting on localhost/loopback, and `false` otherwise (e.g. when binding to `0.0.0.0` on a VPS). |
+| `MINECRAFT_WIKI_ALLOWED_HOSTS` | *Auto* | Comma-separated list of allowed `Host` headers. (e.g. `mcp.example.com:*,123.45.67.89:*`). Only active if security is enabled. |
+| `MINECRAFT_WIKI_ALLOWED_ORIGINS` | *Auto* | Comma-separated list of allowed `Origin` headers. (e.g. `https://mcp.example.com:*`). Only active if security is enabled. |
 
 ## Available Tools
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,4 +43,11 @@ services:
       # Server bind settings (defaults are fine for Docker)
       # - MINECRAFT_WIKI_HOST=0.0.0.0
       # - MINECRAFT_WIKI_PORT=8000
+
+      # DNS rebinding / host security.
+      # By default, security is disabled when binding to 0.0.0.0 (in Docker/VPS).
+      # If exposing to the internet and you want host/origin validation:
+      # - MINECRAFT_WIKI_ENABLE_SECURITY=true
+      # - MINECRAFT_WIKI_ALLOWED_HOSTS=your-domain.com:*,your-vps-ip:*
+      # - MINECRAFT_WIKI_ALLOWED_ORIGINS=https://your-domain.com:*
     restart: unless-stopped

--- a/src/minecraft_wiki_mcp/server.py
+++ b/src/minecraft_wiki_mcp/server.py
@@ -383,6 +383,43 @@ def main() -> None:
         mcp.settings.stateless_http = True
         mcp.settings.json_response = True
 
+        # Configure transport security (DNS rebinding protection)
+        from mcp.server.transport_security import TransportSecuritySettings
+
+        # Determine if security should be enabled
+        enable_sec_env = os.environ.get("MINECRAFT_WIKI_ENABLE_SECURITY")
+        if enable_sec_env is not None:
+            enable_security = enable_sec_env.lower() in ("true", "1", "yes")
+        else:
+            # By default, only enable if host is localhost/loopback
+            enable_security = HOST in ("127.0.0.1", "localhost", "::1")
+
+        allowed_hosts_env = os.environ.get("MINECRAFT_WIKI_ALLOWED_HOSTS")
+        if allowed_hosts_env:
+            allowed_hosts = [h.strip() for h in allowed_hosts_env.split(",") if h.strip()]
+        else:
+            # Default allowed hosts
+            allowed_hosts = [f"{HOST}:*", "127.0.0.1:*", "localhost:*", "[::1]:*"]
+
+        allowed_origins_env = os.environ.get("MINECRAFT_WIKI_ALLOWED_ORIGINS")
+        if allowed_origins_env:
+            allowed_origins = [o.strip() for o in allowed_origins_env.split(",") if o.strip()]
+        else:
+            # Default allowed origins
+            allowed_origins = [
+                f"http://{HOST}:*",
+                f"https://{HOST}:*",
+                "http://127.0.0.1:*",
+                "http://localhost:*",
+                "http://[::1]:*",
+            ]
+
+        mcp.settings.transport_security = TransportSecuritySettings(
+            enable_dns_rebinding_protection=enable_security,
+            allowed_hosts=allowed_hosts,
+            allowed_origins=allowed_origins,
+        )
+
     mcp.run(transport=args.transport)
 
 


### PR DESCRIPTION
This PR resolves HTTP 421 / 403 errors when deploying the streamable-http transport on a VPS.

### Changes:
- Dynamically configures the FastMCP transport security settings in the entrypoint.
- Defaults DNS rebinding protection to `disabled` when binding to external interfaces like `0.0.0.0`.
- Adds environment variables (`MINECRAFT_WIKI_ENABLE_SECURITY`, `MINECRAFT_WIKI_ALLOWED_HOSTS`, `MINECRAFT_WIKI_ALLOWED_ORIGINS`) for explicit configuration.
- Documents the new settings in `README.md` and `docker-compose.yml`.